### PR TITLE
remove pull_request context from actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   create:
     tag:
-  pull_request:
   push: 
   schedule:
     # Runs every thursday at 23:23 GMT. This should make sure this syntax and rust dependencies do not rot for too long.


### PR DESCRIPTION
It was running double the number of jobs because a pull request also is a push.