### PR TITLE
fix #13: no more extra balls

### DIFF
--- a/tb_breakout/src/breakout.rs
+++ b/tb_breakout/src/breakout.rs
@@ -220,7 +220,7 @@ impl toybox_core::Simulation for Breakout {
             }
         }
 
-        let mut state = State {
+        let state = State {
             config: self.clone(),
             state: StateCore {
                 lives: self.start_lives,
@@ -236,11 +236,10 @@ impl toybox_core::Simulation for Breakout {
                 paddle_speed: 4.0,
                 rand: random::Gen::new_child(&mut self.rand),
                 bricks,
-                reset: true,
+                reset: false,
             },
         };
 
-        state.start_ball();
         Box::new(state)
     }
 
@@ -484,6 +483,9 @@ impl toybox_core::State for State {
 
         if self.state.is_dead {
             if buttons.button1 {
+                // Delete old ball(s).
+                self.state.balls.clear();
+                // New ball.
                 self.start_ball();
                 self.state.is_dead = false;
             }
@@ -660,6 +662,7 @@ impl toybox_core::State for State {
             "num_columns" => serde_json::to_string(&screen::BRICKS_ACROSS)?,
             "num_rows" => serde_json::to_string(&screen::ROW_SCORES.len())?,
             "level" => serde_json::to_string(&state.level)?,
+            "is_dead" => serde_json::to_string(&state.is_dead)?,
             "config.ball_start_positions" => serde_json::to_string(&config.ball_start_positions)?,
             _ => Err(QueryError::NoSuchQuery)?,
         })


### PR DESCRIPTION
The true issue was calling start_ball in new_game without setting
is_dead to false; this allowed the player to press the FIRE button and
get a second ball. Now the first ball requires FIRE to begin the game.

We should probably coordinate @etosch to test these wheels via your tests to make sure we really got it done.